### PR TITLE
fix(build): remove redundant mv and add arm64 rename script

### DIFF
--- a/.github/scripts/build-deb-package.sh
+++ b/.github/scripts/build-deb-package.sh
@@ -117,8 +117,7 @@ POSTRM
         ls -la *.deb
     '
 
-# Move package to workspace root
-mv homarr-container-adapter_*.deb ./
-
+# Package is already in workspace root (Docker volume mount)
+# Just verify it exists
 echo "=== Build complete ==="
 ls -la *.deb

--- a/.github/scripts/rename-packages.sh
+++ b/.github/scripts/rename-packages.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Custom rename script for arm64 architecture packages
+set -euo pipefail
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --version) DEBIAN_VERSION="$2"; shift 2 ;;
+        --distro) APT_DISTRO="$2"; shift 2 ;;
+        --component) APT_COMPONENT="$2"; shift 2 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+PACKAGE_NAME="homarr-container-adapter"
+ARCH="arm64"
+
+OLD_NAME="${PACKAGE_NAME}_${DEBIAN_VERSION}_${ARCH}.deb"
+NEW_NAME="${PACKAGE_NAME}_${DEBIAN_VERSION}_${ARCH}+${APT_DISTRO}+${APT_COMPONENT}.deb"
+
+if [ -f "$OLD_NAME" ]; then
+    echo "Renaming package: $OLD_NAME -> $NEW_NAME"
+    mv "$OLD_NAME" "$NEW_NAME"
+    echo "Package renamed successfully"
+else
+    echo "Error: Expected package not found: $OLD_NAME"
+    echo "Available .deb files:"
+    ls -la *.deb 2>/dev/null || echo "None found"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Remove redundant `mv` command that failed with "same file" error (the Docker volume mount already places the file in the correct location)
- Add custom `rename-packages.sh` script for arm64 architecture (shared workflow defaults to `_all.deb` suffix but this package builds `_arm64.deb`)

Fixes the CI failure at: https://github.com/hatlabs/homarr-container-adapter/actions/runs/20196839974

## Test plan

- [ ] CI pipeline passes on this PR
- [ ] Merge to main triggers successful build-release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)