### PR TITLE
feat(homarr): support local icon serving for offline operation

### DIFF
--- a/src/homarr.rs
+++ b/src/homarr.rs
@@ -116,6 +116,9 @@ fn transform_icon_url(icon_path: &str) -> String {
 
     // Transform /usr/share/pixmaps/ paths to /icons/
     if let Some(filename) = icon_path.strip_prefix(PIXMAPS_PREFIX) {
+        if filename.is_empty() {
+            return LOCAL_DEFAULT_ICON.to_string();
+        }
         return format!("/icons/{}", filename);
     }
 
@@ -848,5 +851,12 @@ mod tests {
         // Already transformed /icons/ paths should pass through
         let result = transform_icon_url("/icons/existing.svg");
         assert_eq!(result, "/icons/existing.svg");
+    }
+
+    #[test]
+    fn test_transform_icon_url_pixmaps_trailing_slash_only() {
+        // Edge case: pixmaps path with trailing slash but no filename
+        let result = transform_icon_url("/usr/share/pixmaps/");
+        assert_eq!(result, "/icons/docker.svg");
     }
 }


### PR DESCRIPTION
## Summary

- Add `transform_icon_url()` function to transform file paths to Homarr-compatible URL paths
- Transform `/usr/share/pixmaps/app.png` → `/icons/app.png` for local serving
- Passthrough HTTP/HTTPS URLs unchanged
- Use `/icons/docker.svg` as local fallback (replacing CDN URL)
- Apply transformation to both discovered container apps and Cockpit tile

This enables the Homarr dashboard to work properly without internet connectivity, as marine devices often have intermittent internet access.

## Related Changes Needed

For full offline icon support, the following changes are also required in other repositories:

- **halos-core-containers**: Mount `/usr/share/pixmaps:/app/public/icons:ro` in Homarr container
- **homarr-branding-halos**: Bundle `docker.svg` and `cockpit.svg` in `/usr/share/pixmaps/`

## Test plan

- [x] Unit tests for icon path transformation (8 new tests)
- [x] All 37 tests pass
- [x] `cargo clippy` passes without warnings
- [x] `cargo fmt --check` passes
- [ ] Deploy with volume-mounted Homarr and verify icons work offline

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)