### PR TITLE
refactor: update homarr-branding-halos refs to halos-homarr-branding

### DIFF
--- a/.github/scripts/build-deb-package.sh
+++ b/.github/scripts/build-deb-package.sh
@@ -52,7 +52,7 @@ Package: ${PACKAGE_NAME}
 Version: ${DEB_VERSION}
 Architecture: arm64
 Maintainer: Hat Labs Ltd <info@hatlabs.fi>
-Depends: homarr-branding-halos
+Depends: halos-homarr-branding
 Description: Homarr dashboard adapter for HaLOS
  Adapter service that handles first-boot setup and container
  auto-discovery for the Homarr dashboard.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Rust service that bridges Docker containers with the Homarr dashboard. Two main 
 - `src/main.rs` - CLI entry point with setup/sync/status commands
 - `src/homarr.rs` - Homarr tRPC API client
 - `src/docker.rs` - Docker container discovery (bollard)
-- `src/branding.rs` - Parse branding.toml from homarr-branding-halos
+- `src/branding.rs` - Parse branding.toml from halos-homarr-branding
 - `src/state.rs` - Persistent state (JSON)
 - `src/config.rs` - Adapter configuration
 - `docs/SPEC.md` - Functional requirements
@@ -52,5 +52,5 @@ Native Debian package built with cargo-deb. See `debian/` directory.
 
 ## Related Repos
 
-- `homarr-branding-halos` - Provides `/etc/homarr-branding-halos/branding.toml`
+- `halos-homarr-branding` - Provides `/etc/halos-homarr-branding/branding.toml`
 - `halos-core-containers` - Defines homarr-container

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ labels:
 ## Configuration
 
 Adapter config: `/etc/homarr-container-adapter/config.toml`
-Branding config: `/etc/homarr-branding-halos/branding.toml` (from homarr-branding-halos package)
+Branding config: `/etc/halos-homarr-branding/branding.toml` (from halos-homarr-branding package)
 
 ## Building
 
@@ -63,7 +63,7 @@ cargo test
 ## Related Packages
 
 - `homarr-container` - Homarr dashboard container
-- `homarr-branding-halos` - HaLOS branding configuration
+- `halos-homarr-branding` - HaLOS branding configuration
 
 ## License
 

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/hatlabs/homarr-container-adapter
 
 Package: homarr-container-adapter
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, homarr-branding-halos
+Depends: ${shlibs:Depends}, ${misc:Depends}, halos-homarr-branding
 Description: Homarr dashboard adapter for HaLOS
  Adapter service that handles first-boot setup and container
  auto-discovery for the Homarr dashboard.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,7 +61,7 @@ src/
 - Path resolution
 
 #### branding.rs
-- Parse branding.toml from homarr-branding-halos
+- Parse branding.toml from halos-homarr-branding
 - Type definitions for identity, theme, credentials, board config
 - Validation of branding settings
 
@@ -142,7 +142,7 @@ src/
 ```
 /etc/homarr-container-adapter/config.toml  (adapter config)
          │
-         └──► branding_file ──► /etc/homarr-branding-halos/branding.toml
+         └──► branding_file ──► /etc/halos-homarr-branding/branding.toml
          │
          └──► state_file ──► /var/lib/homarr-container-adapter/state.json
 ```
@@ -165,7 +165,7 @@ src/
 ### Runtime Dependencies
 - Docker daemon (socket access)
 - Homarr container running
-- homarr-branding-halos package installed
+- halos-homarr-branding package installed
 
 ### Build Dependencies
 - Rust toolchain (1.70+)

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -67,7 +67,7 @@ labels:
 homarr_url = "http://localhost:7575"
 
 # Path to branding configuration
-branding_file = "/etc/homarr-branding-halos/branding.toml"
+branding_file = "/etc/halos-homarr-branding/branding.toml"
 
 # State persistence file
 state_file = "/var/lib/homarr-container-adapter/state.json"
@@ -81,7 +81,7 @@ debug = false
 
 ### Branding Configuration
 
-See homarr-branding-halos package for branding configuration schema.
+See halos-homarr-branding package for branding configuration schema.
 
 ## API Interactions
 

--- a/src/branding.rs
+++ b/src/branding.rs
@@ -1,4 +1,4 @@
-//! Branding configuration from homarr-branding-halos package
+//! Branding configuration from halos-homarr-branding package
 
 use serde::Deserialize;
 use std::fs;
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use crate::error::{AdapterError, Result};
 
-/// Branding configuration loaded from /etc/homarr-branding-halos/branding.toml
+/// Branding configuration loaded from /etc/halos-homarr-branding/branding.toml
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 pub struct BrandingConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,7 +36,7 @@ fn default_homarr_url() -> String {
 }
 
 fn default_branding_file() -> String {
-    "/etc/homarr-branding-halos/branding.toml".to_string()
+    "/etc/halos-homarr-branding/branding.toml".to_string()
 }
 
 fn default_state_file() -> String {


### PR DESCRIPTION
## Summary
Update all references following the package rename from `homarr-branding-halos` to `halos-homarr-branding` for consistent naming convention (halos- prefix for HaLOS packages).

## Changes
- `src/config.rs` - Updated default branding file path
- `src/branding.rs` - Updated module documentation  
- `debian/control` - Updated dependency name
- `.github/scripts/build-deb-package.sh` - Updated dependency in generated control file
- `AGENTS.md`, `README.md`, `docs/SPEC.md`, `docs/ARCHITECTURE.md` - Updated documentation

## Related PRs
This is part of a coordinated rename across multiple repositories:
- hatlabs/halos-homarr-branding (repo renamed, PR merged)
- hatlabs/halos-distro#50
- hatlabs/halos-core-containers#10
- hatlabs/halos-metapackages (PR pending)

## Test plan
- [ ] PR checks pass (cargo build/test)
- [ ] Verify adapter finds branding config at new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)