### PR TITLE
fix(config): use correct default Homarr port

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,7 @@ pub struct Config {
 }
 
 fn default_homarr_url() -> String {
-    "http://localhost:7575".to_string()
+    "http://localhost:80".to_string()
 }
 
 fn default_branding_file() -> String {


### PR DESCRIPTION
## Summary

- Fix default Homarr URL from `localhost:7575` to `localhost:80`
- The halos-homarr-container docker-compose exposes Homarr on port 80 (mapping 80→7575)
- The adapter was trying to connect to port 7575 on the host, causing connection refused errors

## Test plan

- [x] Tested on halos.local - adapter now connects successfully
- [x] First-boot setup completes without errors
- [x] Container discovery works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)