### PR TITLE
refactor: use relative icon URLs instead of asset server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,6 @@ chrono = { version = "0.4", features = ["serde"] }
 # URL encoding
 urlencoding = "2"
 
-# System hostname
-gethostname = "1"
-
 [dev-dependencies]
 tokio-test = "0.4"
 tempfile = "3"

--- a/etc/config.toml
+++ b/etc/config.toml
@@ -10,12 +10,6 @@
 # Default: http://localhost:80
 # homarr_url = "http://localhost:80"
 
-# Asset server URL for icons (must be accessible from the browser)
-# The asset server runs on port 8771 and serves icons from /usr/share/pixmaps.
-# This URL is embedded in Homarr tiles, so it must be reachable from the user's browser.
-# Default: http://<hostname>.local:8771 (uses system hostname with mDNS)
-# asset_server_url = "http://mydevice.local:8771"
-
 # Path to branding configuration
 # Default: /etc/halos-homarr-branding/branding.toml
 # branding_file = "/etc/halos-homarr-branding/branding.toml"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,5 @@
 //! Adapter configuration
 
-use gethostname::gethostname;
 use serde::Deserialize;
 use std::fs;
 use std::path::Path;
@@ -14,11 +13,6 @@ pub struct Config {
     /// Homarr API URL
     #[serde(default = "default_homarr_url")]
     pub homarr_url: String,
-
-    /// Asset server base URL for serving icons
-    /// This server hosts /icons/ from /usr/share/pixmaps
-    #[serde(default = "default_asset_server_url")]
-    pub asset_server_url: String,
 
     /// Path to branding config file
     #[serde(default = "default_branding_file")]
@@ -41,14 +35,6 @@ fn default_homarr_url() -> String {
     "http://localhost:80".to_string()
 }
 
-fn default_asset_server_url() -> String {
-    let hostname = gethostname()
-        .into_string()
-        .unwrap_or_else(|_| "localhost".to_string());
-    // Use mDNS .local suffix for local network access
-    format!("http://{}.local:8771", hostname)
-}
-
 fn default_branding_file() -> String {
     "/etc/halos-homarr-branding/branding.toml".to_string()
 }
@@ -65,7 +51,6 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             homarr_url: default_homarr_url(),
-            asset_server_url: default_asset_server_url(),
             branding_file: default_branding_file(),
             state_file: default_state_file(),
             docker_socket: default_docker_socket(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ async fn run_watch(config: &Config) -> Result<()> {
     let branding = branding::BrandingConfig::load(&config.branding_file)?;
 
     // Create Homarr client and login
-    let client = homarr::HomarrClient::new(&config.homarr_url, &config.asset_server_url)?;
+    let client = homarr::HomarrClient::new(&config.homarr_url)?;
     client.ensure_logged_in(&branding).await?;
 
     // Do initial sync of existing containers
@@ -222,7 +222,7 @@ async fn run_sync(config: &Config) -> Result<()> {
     let discovered = docker::discover_apps(config).await?;
 
     // Create client and login
-    let client = homarr::HomarrClient::new(&config.homarr_url, &config.asset_server_url)?;
+    let client = homarr::HomarrClient::new(&config.homarr_url)?;
     client.ensure_logged_in(&branding).await?;
 
     // Add new apps
@@ -260,7 +260,7 @@ async fn run_setup(config: &Config) -> Result<()> {
     let branding = branding::BrandingConfig::load(&config.branding_file)?;
 
     // Create Homarr client
-    let client = homarr::HomarrClient::new(&config.homarr_url, &config.asset_server_url)?;
+    let client = homarr::HomarrClient::new(&config.homarr_url)?;
 
     // Check onboarding status
     let step = client.get_onboarding_step().await?;


### PR DESCRIPTION
## Summary
- Change icon URL generation from absolute (http://host:8771/icons/...) to relative (/icons/...)
- Remove asset_server_url configuration since icons are now served by Homarr's nginx
- Remove gethostname dependency (no longer needed)

## Changes
- **src/config.rs**: Remove `asset_server_url` field and `default_asset_server_url()` function
- **src/homarr.rs**: Simplify `transform_icon_url()` to return relative paths; update `HomarrClient::new()` signature
- **src/main.rs**: Update all `HomarrClient::new()` calls
- **etc/config.toml**: Remove asset_server_url documentation
- **Cargo.toml**: Remove unused gethostname dependency

## Related
This is a companion change to hatlabs/halos-core-containers#13 which patches Homarr's nginx to serve icons directly from /icons/.

## Test plan
- [x] All unit tests pass (38 tests)
- [ ] Integration test on device with halos-core-containers changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)