### PR TITLE
chore: relax state directory permissions to 755

### DIFF
--- a/.github/scripts/build-deb-package.sh
+++ b/.github/scripts/build-deb-package.sh
@@ -73,7 +73,7 @@ case "$1" in
     configure)
         # Create state directory with proper permissions
         mkdir -p /var/lib/homarr-container-adapter
-        chmod 700 /var/lib/homarr-container-adapter
+        chmod 755 /var/lib/homarr-container-adapter
 
         # Enable and start the service
         if [ -d /run/systemd/system ]; then

--- a/debian/postinst
+++ b/debian/postinst
@@ -5,7 +5,7 @@ case "$1" in
     configure)
         # Create state directory with proper permissions
         mkdir -p /var/lib/homarr-container-adapter
-        chmod 700 /var/lib/homarr-container-adapter
+        chmod 755 /var/lib/homarr-container-adapter
 
         # Enable and start the service
         if [ -d /run/systemd/system ]; then


### PR DESCRIPTION
## Summary
- Change `/var/lib/homarr-container-adapter` permissions from 700 to 755

## Rationale
The state file only contains operational data:
- `first_boot_completed` flag
- Discovered app names, URLs, timestamps
- Removed app container IDs

No secrets are stored here (credentials are in `/etc/halos-homarr-branding/branding.toml`). 700 was unnecessarily restrictive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)