### PR TITLE
fix: include pingUrl in app.update payload

### DIFF
--- a/src/homarr.rs
+++ b/src/homarr.rs
@@ -545,7 +545,8 @@ impl HomarrClient {
                 "name": app.name,
                 "description": app.description.clone().unwrap_or_default(),
                 "iconUrl": icon_url,
-                "href": app.url
+                "href": app.url,
+                "pingUrl": ""
             }
         });
 


### PR DESCRIPTION
## Summary
- Add `pingUrl: ""` to the app.update payload

## Problem
The Homarr `app.update` API endpoint requires the `pingUrl` field to be present. The zod validation was failing with:
```
Invalid input: expected string, received undefined
```

## Solution
Include `pingUrl: ""` (empty string) in the update payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)