### PR TITLE
fix: add updated apps to board

### DIFF
--- a/src/homarr.rs
+++ b/src/homarr.rs
@@ -597,6 +597,9 @@ impl HomarrClient {
         if let Some(existing_app) = existing {
             // Update existing app instead of creating duplicate
             self.update_app(&existing_app.id, app).await?;
+            // Also ensure it's on the board (it might exist but not be on this board)
+            self.add_discovered_app_to_board(&existing_app.id, app, board_name)
+                .await?;
             return Ok(existing_app.id);
         }
 


### PR DESCRIPTION
## Summary
- When updating an existing app, also add it to the board

## Problem
The update path returned early without calling `add_discovered_app_to_board()`. If an app existed in Homarr but wasn't on the current board, updating it would not add it.

## Solution
After updating an existing app, also call `add_discovered_app_to_board()` to ensure it appears on the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)