### PR TITLE
feat: auto-derive pingUrl from app URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,9 @@ clap = { version = "4", features = ["derive"] }
 # Time
 chrono = { version = "0.4", features = ["serde"] }
 
-# URL encoding
+# URL encoding and parsing
 urlencoding = "2"
+url = "2"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -42,10 +42,12 @@ Containers opt-in to Homarr visibility using labels:
 |-------|----------|-------------|
 | `homarr.enable` | Yes | Must be "true" to enable |
 | `homarr.name` | Yes | Display name in Homarr |
-| `homarr.url` | Yes | URL to access the app |
+| `homarr.url` | Yes | URL to access the app (used for clicking) |
 | `homarr.description` | No | App description |
 | `homarr.icon` | No | Icon URL |
 | `homarr.category` | No | Category grouping |
+
+**Note:** The `pingUrl` for health checks is automatically derived by replacing the hostname with `localhost`. This allows Homarr (running in a container) to reach apps for health checks while the display URL can use the external hostname (e.g., `halos.local`).
 
 Example:
 ```yaml


### PR DESCRIPTION
## Summary
- Automatically derive `pingUrl` by replacing the hostname with `localhost`
- This allows Homarr (running in a container) to reach apps for health checks
- Display URL can still use external hostname (e.g., `halos.local`)

## Example
- App URL: `http://halos.local:3000`
- Derived pingUrl: `http://localhost:3000/`

## Changes
- Add `derive_ping_url()` function to replace hostname with localhost
- Add `url` crate dependency for URL parsing
- Update SPEC.md to document auto-derivation
- Add 5 tests for derive_ping_url

## Test plan
- [x] `cargo test` - 49 tests pass
- [x] `cargo clippy` - no warnings
- [ ] Manual test: Run sync and verify health checks work

🤖 Generated with [Claude Code](https://claude.com/claude-code)