### PR TITLE
fix: use host.docker.internal for pingUrl health checks

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -47,7 +47,7 @@ Containers opt-in to Homarr visibility using labels:
 | `homarr.icon` | No | Icon URL |
 | `homarr.category` | No | Category grouping |
 
-**Note:** The `pingUrl` for health checks is automatically derived by replacing the hostname with `localhost`. This allows Homarr (running in a container) to reach apps for health checks while the display URL can use the external hostname (e.g., `halos.local`).
+**Note:** The `pingUrl` for health checks is automatically derived by replacing the hostname with `host.docker.internal`. This allows Homarr (running in a container) to reach apps on the host for health checks while the display URL can use the external hostname (e.g., `halos.local`). Requires `extra_hosts: ["host.docker.internal:host-gateway"]` in Homarr's docker-compose.yml.
 
 Example:
 ```yaml


### PR DESCRIPTION
## Summary
- Change `derive_ping_url` to use `host.docker.internal` instead of `localhost`
- Update documentation in SPEC.md to reflect the change
- Update unit tests with new expected values

## Context
The previous approach used `localhost` for pingUrl, assuming Homarr could reach host services via localhost. However, `localhost` inside a Docker container refers to the container itself, not the host machine. This caused all health checks to fail with "fetch failed".

The fix uses `host.docker.internal` which, when combined with `extra_hosts: ["host.docker.internal:host-gateway"]` in Homarr's docker-compose.yml, correctly routes to the host machine.

**Related PR**: hatlabs/halos-core-containers#16 adds the required `extra_hosts` configuration to Homarr.

## Test plan
- [ ] All unit tests pass (verified locally: 49 tests pass)
- [ ] Deploy with updated Homarr container
- [ ] Verify app health check dots show correct status

🤖 Generated with [Claude Code](https://claude.com/claude-code)