### PR TITLE
feat: add lefthook pre-commit hooks for format/lint checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,33 @@ cargo build --release
 cargo test
 ```
 
+## Development
+
+### Pre-commit Hooks
+
+This project uses [lefthook](https://github.com/evilmartians/lefthook) for pre-commit hooks to run format and lint checks locally before commits.
+
+**Setup:**
+
+```bash
+# Install lefthook (one-time)
+brew install lefthook
+
+# Enable hooks in this repo
+./run hooks-install
+```
+
+**What it checks:**
+
+- `cargo fmt --check` - Code formatting
+- `cargo clippy --all-targets --all-features -- -D warnings` - Linting
+
+**Skip hooks when needed:**
+
+```bash
+git commit --no-verify -m "WIP: message"
+```
+
 ## Related Packages
 
 - `homarr-container` - Homarr dashboard container

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,12 @@
+pre-commit:
+  parallel: true
+  commands:
+    rust-fmt-check:
+      glob: "*.rs"
+      run: cargo fmt --check
+      fail_text: "Run 'cargo fmt' to fix formatting."
+
+    rust-clippy:
+      glob: "*.rs"
+      run: cargo clippy --all-targets --all-features -- -D warnings
+      fail_text: "Fix clippy warnings before committing."

--- a/run
+++ b/run
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# usage: ./run command [argument ...]
+#
+# Commands used during development / CI.
+# Also, executable documentation for project dev practices.
+#
+# See https://death.andgravity.com/run-sh
+# for an explanation of how it works and why it's useful.
+
+################################################################################
+# Core Development Commands
+
+function build {
+  #@ Build project (debug by default, use --release for release build)
+  #@ Category: Core Development
+  cargo build "$@"
+}
+
+function clean {
+  #@ Clean all build artifacts
+  #@ Category: Core Development
+  cargo clean "$@"
+}
+
+function check {
+  #@ Run cargo check and clippy
+  #@ Category: Core Development
+  cargo check --all-targets
+  cargo clippy --all-targets --all-features -- -D warnings
+}
+
+function fmt {
+  #@ Format code with rustfmt
+  #@ Category: Core Development
+  cargo fmt
+}
+
+function fmt-check {
+  #@ Check code formatting without making changes
+  #@ Category: Core Development
+  cargo fmt --check
+}
+
+################################################################################
+# Testing Commands
+
+function test {
+  #@ Run all tests
+  #@ Category: Testing
+  cargo test --all-features "$@"
+}
+
+################################################################################
+# Development Setup
+
+function hooks-install {
+  #@ Install pre-commit hooks using lefthook
+  #@ Category: Development Setup
+  if ! command -v lefthook &> /dev/null; then
+    echo "Error: lefthook not found. Install with: brew install lefthook"
+    exit 1
+  fi
+  lefthook install
+  echo "✅ Pre-commit hooks installed"
+}
+
+function hooks-run {
+  #@ Run pre-commit hooks manually
+  #@ Category: Development Setup
+  if ! command -v lefthook &> /dev/null; then
+    echo "Error: lefthook not found. Install with: brew install lefthook"
+    exit 1
+  fi
+  lefthook run pre-commit
+}
+
+################################################################################
+# CI/CD Commands
+
+function ci-check {
+  #@ Run CI verification checks (format, lint, test)
+  #@ Category: CI/CD
+  echo "🔍 Running CI checks..."
+  fmt-check
+  check
+  test
+  echo "✅ All CI checks passed"
+}
+
+################################################################################
+# Help System
+
+function help {
+  #@ Show this help message
+  #@ Category: Help
+  echo "Available commands:"
+  echo ""
+
+  # Extract function definitions and their help comments
+  awk '/^function / {
+    fname = $2
+    sub(/[({].*/, "", fname)
+    getline
+    if ($0 ~ /#@/) {
+      desc = $0
+      sub(/.*#@ /, "", desc)
+      sub(/ *$/, "", desc)
+      getline
+      if ($0 ~ /#@ Category:/) {
+        cat = $0
+        sub(/.*Category: /, "", cat)
+        sub(/ *$/, "", cat)
+        if (!seen[cat]++) categories[++cat_count] = cat
+        commands[cat, ++cmd_count[cat]] = fname
+        descriptions[cat, cmd_count[cat]] = desc
+      }
+    }
+  }
+  END {
+    for (i = 1; i <= cat_count; i++) {
+      cat = categories[i]
+      print "\n" cat ":"
+      for (j = 1; j <= cmd_count[cat]; j++) {
+        printf "  %-20s %s\n", commands[cat, j], descriptions[cat, j]
+      }
+    }
+  }' "$0"
+
+  echo ""
+  echo "Usage: ./run <command> [arguments...]"
+}
+
+################################################################################
+# Main dispatcher
+
+# If no arguments provided, show help
+if [ $# -eq 0 ]; then
+  help
+  exit 0
+fi
+
+# Get the command name
+cmd=$1
+shift
+
+# Check if function exists
+if declare -f "$cmd" > /dev/null; then
+  # Run the command with timing
+  TIMEFORMAT=$'\nTask completed in %3lR'
+  time "$cmd" "$@"
+else
+  echo "Error: Unknown command '$cmd'"
+  echo
+  echo "Run './run help' to see available commands"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Add lefthook.yml with cargo fmt and clippy checks
- Create run script with hooks-install command  
- Update README with developer setup instructions

## Test plan

- [x] Tested `lefthook run pre-commit` locally
- [x] Verified run script `hooks-install` command works
- [x] Confirmed hooks run on commit

## Developer Setup

After merging, developers should:
```bash
brew install lefthook
./run hooks-install
```

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)