### PR TITLE
fix: remove hard-coded hostname references

### DIFF
--- a/run
+++ b/run
@@ -24,9 +24,6 @@ readonly SCRIPT="$PROJECT_ROOT/$(basename "$0")"
 # Docker image name for cross-compilation
 readonly DOCKER_IMAGE="homarr-adapter-builder"
 
-# Default deploy target
-readonly DEFAULT_DEPLOY_TARGET="halos.local"
-
 ################################################################################
 # Build Commands
 
@@ -126,10 +123,17 @@ function lint {
 # Deploy Commands
 
 function deploy {
-  #@ Deploy ARM64 binary to test server (default: halos.local)
-  #@ Usage: ./run deploy [target_host]
+  #@ Deploy ARM64 binary to test server
+  #@ Usage: ./run deploy <target_host>
   #@ Category: Deploy
-  local target="${1:-$DEFAULT_DEPLOY_TARGET}"
+  local target="${1:-}"
+
+  if [[ -z "$target" ]]; then
+    echo "Usage: ./run deploy <target_host>"
+    echo ""
+    echo "Example: ./run deploy pi@myhost.local"
+    return 1
+  fi
 
   echo "Deploying to $target..."
 
@@ -263,10 +267,10 @@ function help {
   echo "Usage: ./run <command> [arguments...]"
   echo ""
   echo "Examples:"
-  echo "  ./run build-arm64      # Cross-compile for Raspberry Pi"
-  echo "  ./run deploy           # Deploy to halos.local"
-  echo "  ./run deploy-build     # Build and deploy in one step"
-  echo "  ./run logs-follow      # Watch service logs"
+  echo "  ./run build-arm64               # Cross-compile for Raspberry Pi"
+  echo "  ./run deploy pi@myhost.local    # Deploy to test server"
+  echo "  ./run deploy-build myhost.local # Build and deploy in one step"
+  echo "  ./run logs-follow               # Watch service logs"
 }
 
 ################################################################################

--- a/src/authelia.rs
+++ b/src/authelia.rs
@@ -128,11 +128,12 @@ pub fn sync_credentials<P: AsRef<Path>>(
     let password_hash = hash_password(password)?;
 
     // Create user entry
+    // Default email uses example.local (RFC 2606 reserved domain) when not provided
     let user = User {
         displayname: username.to_string(),
         password: password_hash,
         email: email
-            .unwrap_or(&format!("{}@halos.local", username))
+            .unwrap_or(&format!("{}@example.local", username))
             .to_string(),
         groups: vec!["admins".to_string()],
     };
@@ -187,7 +188,7 @@ mod tests {
             User {
                 displayname: "Admin User".to_string(),
                 password: "$argon2id$test".to_string(),
-                email: "admin@halos.local".to_string(),
+                email: "admin@test.example.local".to_string(),
                 groups: vec!["admins".to_string()],
             },
         );
@@ -202,7 +203,7 @@ mod tests {
         assert!(loaded.users.contains_key("admin"));
         let admin = loaded.users.get("admin").unwrap();
         assert_eq!(admin.displayname, "Admin User");
-        assert_eq!(admin.email, "admin@halos.local");
+        assert_eq!(admin.email, "admin@test.example.local");
     }
 
     #[test]
@@ -231,9 +232,9 @@ mod tests {
         // Sync without email
         sync_credentials(&db_path, "admin", "password", None).unwrap();
 
-        // Verify default email
+        // Verify default email uses example.local placeholder domain
         let db = UsersDatabase::load(&db_path).unwrap();
         let user = db.users.get("admin").unwrap();
-        assert_eq!(user.email, "admin@halos.local");
+        assert_eq!(user.email, "admin@example.local");
     }
 }

--- a/src/homarr.rs
+++ b/src/homarr.rs
@@ -165,7 +165,7 @@ const DEFAULT_ICON: &str = "/icons/docker.svg";
 /// Derive a host.docker.internal-based ping URL from the app URL.
 /// Replaces the hostname with host.docker.internal so Homarr container can reach the app.
 /// Note: Requires `extra_hosts: ["host.docker.internal:host-gateway"]` in Homarr's docker-compose.yml
-/// Example: "http://halos.local:3000/path" -> "http://host.docker.internal:3000/path"
+/// Example: "http://myhost.local:3000/path" -> "http://host.docker.internal:3000/path"
 fn derive_ping_url(app_url: &str) -> Option<String> {
     match url::Url::parse(app_url) {
         Ok(mut parsed) => {
@@ -1336,7 +1336,7 @@ mod tests {
 
     #[test]
     fn test_derive_ping_url_replaces_hostname() {
-        let result = derive_ping_url("http://halos.local:3000");
+        let result = derive_ping_url("http://test.example.local:3000");
         assert_eq!(
             result,
             Some("http://host.docker.internal:3000/".to_string())
@@ -1345,7 +1345,7 @@ mod tests {
 
     #[test]
     fn test_derive_ping_url_preserves_path() {
-        let result = derive_ping_url("http://halos.local:8086/api/v2");
+        let result = derive_ping_url("http://test.example.local:8086/api/v2");
         assert_eq!(
             result,
             Some("http://host.docker.internal:8086/api/v2".to_string())
@@ -1354,13 +1354,13 @@ mod tests {
 
     #[test]
     fn test_derive_ping_url_preserves_https() {
-        let result = derive_ping_url("https://halos.local:443/app");
+        let result = derive_ping_url("https://test.example.local:443/app");
         assert_eq!(result, Some("https://host.docker.internal/app".to_string()));
     }
 
     #[test]
     fn test_derive_ping_url_handles_no_port() {
-        let result = derive_ping_url("http://halos.local/dashboard");
+        let result = derive_ping_url("http://test.example.local/dashboard");
         assert_eq!(
             result,
             Some("http://host.docker.internal/dashboard".to_string())

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -285,7 +285,7 @@ url = "http://localhost:8080"
             "signalk",
             r#"
 name = "Signal K"
-url = "http://halos.local:3000"
+url = "http://test.example.local:3000"
 description = "Marine data server"
 icon_url = "/icons/signalk.png"
 category = "Marine"


### PR DESCRIPTION
## Summary
- Remove `DEFAULT_DEPLOY_TARGET` from run script
- Update `deploy` function to require explicit target parameter  
- Change default email domain from specific hostname to `example.local` (RFC 2606 reserved)
- Update doc comment example with generic hostname
- Update test data to use `test.example.local`

## Test plan
- [ ] Verify lint check passes: `.github/scripts/check-hardcoded-hostnames.sh`
- [ ] Run cargo test to verify test changes work
- [ ] Verify deploy function shows usage when target is not provided

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)