### PR TITLE
docs(agents): point version-bump guidance at canonical policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ git push
 
 **Note:** `debian/changelog` is generated dynamically by CI from the VERSION file.
 
-**CI Enforcement**: PRs that change package-affecting files must include a VERSION bump or CI will fail. Changes to docs, tests, CI config, and dev tooling are automatically excluded.
+**CI Enforcement**: VERSION bumps are per release cycle, not per PR — CI fails only on the PR that opens a new cycle (when VERSION still matches the latest stable release and the PR touches package-affecting files); later PRs in the same cycle must not bump. See the workspace `AGENTS.md` version-bump policy for the full decision procedure.
 
 ## Packaging
 


### PR DESCRIPTION
Replaces the per-PR enforcement line (which read as "any package-affecting PR must bump VERSION") with a one-line per-cycle summary that points at the canonical decision procedure in the workspace `AGENTS.md` (halos-org/halos). Behavior unchanged — matches what CI already enforces. Docs only.

Closes #70.