### PR TITLE
Anchor discovered Signal K webapps at 0,3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "homarr-container-adapter"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "argon2",

--- a/src/signalk.rs
+++ b/src/signalk.rs
@@ -214,8 +214,8 @@ async fn discover_webapps_inner(
                 priority: 45,
                 width: 2,
                 height: 1,
-                x_offset: None,
-                y_offset: None,
+                x_offset: Some(0),
+                y_offset: Some(3),
             },
         });
     }
@@ -432,8 +432,8 @@ mod tests {
                     priority: 45,
                     width: 2,
                     height: 1,
-                    x_offset: None,
-                    y_offset: None,
+                    x_offset: Some(0),
+                    y_offset: Some(3),
                 },
             });
         }


### PR DESCRIPTION
## Motivation

Part of the default Homarr board rework: give the dynamically discovered Signal K webapp tiles a predictable home below the primary tiles instead of letting them fall to the board origin.

## Approach

In `src/signalk.rs`, the `LayoutConfig` for discovered webapps:
- `x_offset` None → `Some(0)`, `y_offset` None → `Some(3)` (soft anchor at column 0, row 3; size unchanged at 2×1)

The duplicated `LayoutConfig` in `test_conversion_from_api_data` is synced to match production (it asserts only on `priority`, so behavior is unchanged). Cargo.lock is synced to the 0.4.9 version already on main.

No VERSION bump: VERSION (0.4.9) already differs from the latest stable tag `v0.4.8+1`, so the release cycle is already open.

All 140 tests pass; fmt and clippy clean.

## Coordination

One of four coordinated PRs adjusting the dashboard layout (cockpit-config, core-containers, marine signalk-server, homarr-container-adapter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)